### PR TITLE
Add more keywords for various categories

### DIFF
--- a/REQ.md
+++ b/REQ.md
@@ -84,13 +84,13 @@ This section outlines requirements for the server-side logic, including data fet
 > | ♨    | "steam"                                                      |
 > | 👴    | "gog", "good old games"                                      |
 > | 🎮    | "ps4", "ps5", "playstation", "psn", "ps+"            |
-> | 📀    | "dvd", "blu-ray", "bluray", "4k", "uhd", "film"          |
+> | 📀    | "dvd", "blu-ray", "bluray", "4k", "uhd", "film", "movie", "youtube", "animation" |
 > | 👕    | "shirt", "merch"                                  |
-> | 💻    | "pc", "computer", "controller", "windows", "cable", "laptop" |
-> | 📚    | "book"                                                       |
+> | 💻    | "pc", "computer", "controller", "windows", "cable", "laptop", "monitors", "accessories", "apple" |
+> | 📚    | "book", "kindle", "hardcover"                                |
 > | 📦    | "humble", "bundle"                                    |
-> | 🕴    | "figure"                                                     |
-> | 🧱    | "LEGO"                                     |
+> | 🕴    | "figure", "plush", "costume", "toy", "ornament", "amiibo"    |
+> | 🧱    | "LEGO", "nanoblock"                                     |
 >
 > - **ImplementedBy:** [functions/deals.js](functions/deals.js)
 > - **TestedBy:** [tests/deals.test.js](tests/deals.test.js)

--- a/REQ.md
+++ b/REQ.md
@@ -86,7 +86,7 @@ This section outlines requirements for the server-side logic, including data fet
 > | 🎮    | "ps4", "ps5", "playstation", "psn", "ps+"            |
 > | 📀    | "dvd", "blu-ray", "bluray", "4k", "uhd", "film", "movie", "youtube", "animation" |
 > | 👕    | "shirt", "merch"                                  |
-> | 💻    | "pc", "computer", "controller", "windows", "cable", "laptop", "monitors", "accessories", "apple" |
+> | 💻    | "pc", "computer", "controller", "windows", "cable", "laptop", "monitor", "accessories", "apple" |
 > | 📚    | "book", "kindle", "hardcover"                                |
 > | 📦    | "humble", "bundle"                                    |
 > | 🕴    | "figure", "plush", "costume", "toy", "ornament", "amiibo"    |

--- a/functions/deals.js
+++ b/functions/deals.js
@@ -9,7 +9,7 @@ const PLATFORM_MAP = [
   { keywords: ['ps4', 'ps5', 'playstation', 'psn', 'ps+'], emoji: '🎮' }, 
   { keywords: ['dvd', 'blu-ray', 'bluray', '4k', 'uhd', 'film', 'movie', 'youtube', 'animation'], emoji: '📀' },
   { keywords: ['shirt', 'merch'], emoji: '👕' }, 
-  { keywords: ['pc', 'computer', 'controller', 'windows', 'cable', 'laptop', 'monitors', 'accessories', 'apple'], emoji: '💻' },
+  { keywords: ['pc', 'computer', 'controller', 'windows', 'cable', 'laptop', 'monitor', 'accessories', 'apple'], emoji: '💻' },
   { keywords: ['book', 'kindle', 'hardcover'], emoji: '📚' },
   { keywords: ['humble', 'bundle'], emoji: '📦' },
   { keywords: ['lego', 'nanoblock'], emoji: '🧱' },

--- a/functions/deals.js
+++ b/functions/deals.js
@@ -1,18 +1,18 @@
 // Fetch latest posts from Wario64 on Bluesky and expose as JSON
 
 const PLATFORM_MAP = [
+  { keywords: ['figure', 'plush', 'costume', 'toy', 'ornament', 'amiibo'], emoji: '🕴' }, // Moved up
   { keywords: ['nintendo', 'switch', 'eshop', 'game-key'], emoji: '🔀' }, 
   { keywords: ['xbox'], emoji: '🟢' },
   { keywords: ['steam'], emoji: '♨' },
   { keywords: ['gog', 'good old games'], emoji: '👴' },
   { keywords: ['ps4', 'ps5', 'playstation', 'psn', 'ps+'], emoji: '🎮' }, 
-  { keywords: ['dvd', 'blu-ray', 'bluray', '4k', 'uhd', 'film'], emoji: '📀' }, 
+  { keywords: ['dvd', 'blu-ray', 'bluray', '4k', 'uhd', 'film', 'movie', 'youtube', 'animation'], emoji: '📀' },
   { keywords: ['shirt', 'merch'], emoji: '👕' }, 
-  { keywords: ['pc', 'computer', 'controller', 'windows', 'cable', 'laptop'], emoji: '💻' },
-  { keywords: ['book'], emoji: '📚' },
+  { keywords: ['pc', 'computer', 'controller', 'windows', 'cable', 'laptop', 'monitors', 'accessories', 'apple'], emoji: '💻' },
+  { keywords: ['book', 'kindle', 'hardcover'], emoji: '📚' },
   { keywords: ['humble', 'bundle'], emoji: '📦' },
-  { keywords: ['figure'], emoji: '🕴' },
-  { keywords: ['lego'], emoji: '🧱' }, 
+  { keywords: ['lego', 'nanoblock'], emoji: '🧱' },
 ];
 
 function getPlatformEmoji(description) {

--- a/tests/deals.test.js
+++ b/tests/deals.test.js
@@ -296,13 +296,29 @@ describe('onRequest handler for /deals', () => {
       { name: 'Art Book limited edition', expectedEmoji: '📚' },
       { name: 'Humble Bundle for charity', expectedEmoji: '📦' },
       { name: 'Collectible Figure', expectedEmoji: '🕴' },
-      // New Keywords
+      // New Keywords for existing emojis from previous updates
       { name: 'PS+ discount', expectedEmoji: '🎮' },
       { name: 'eShop card for Nintendo', expectedEmoji: '🔀' },
       { name: 'Game-key for Switch', expectedEmoji: '🔀' },
       { name: 'Official Merch store', expectedEmoji: '👕' },
       { name: 'Film on Blu-ray', expectedEmoji: '📀' },
       { name: 'LEGO Star Wars set', expectedEmoji: '🧱' },
+      // Keywords for this request
+      { name: 'Kindle edition book', expectedEmoji: '📚' },
+      { name: 'Hardcover novel', expectedEmoji: '📚' },
+      { name: 'Cute Plush toy', expectedEmoji: '🕴' },
+      { name: 'Halloween costume figure', expectedEmoji: '🕴' },
+      { name: 'Action figure toy', expectedEmoji: '🕴' },
+      { name: 'Christmas ornament figure', expectedEmoji: '🕴' },
+      { name: 'amiibo figure for Switch', expectedEmoji: '🕴' },
+      { name: 'Gaming Monitors on sale', expectedEmoji: '💻' },
+      // New keywords from this batch
+      { name: 'PC Gaming Accessories', expectedEmoji: '💻' },
+      { name: 'New Apple Macbook Air', expectedEmoji: '💻' },
+      { name: 'Movie night Blu-ray', expectedEmoji: '📀' },
+      { name: 'Youtube streaming device', expectedEmoji: '📀' },
+      { name: 'Classic Animation Collection DVD', expectedEmoji: '📀' },
+      { name: 'Nanoblock Pokemon set', expectedEmoji: '🧱' },
       // LEGO Priority Test
       { name: 'Nintendo Switch LEGO Game', expectedEmoji: '🔀' }, // Switch has higher priority than LEGO
       { name: 'LEGO PS5 Controller', expectedEmoji: '🎮' }, // PS5 has higher priority than LEGO


### PR DESCRIPTION
- Added 'Accessories', 'Apple' to '💻' (PC/Other).
- Added 'Movie', 'Youtube', 'Animation' to '📀' (Physical Media).
- Added 'Nanoblock' to '🧱' (LEGO).
- Updated tests and REQ.md to reflect these additions.