### PR TITLE
feat: Update keywords and requirements to map XBL to Xbox

### DIFF
--- a/REQ.md
+++ b/REQ.md
@@ -80,7 +80,7 @@ This section outlines requirements for the server-side logic, including data fet
 > | Emoji | Keywords                                                     |
 > | :---- | :----------------------------------------------------------- |
 > | 🔀    | "nintendo", "switch", "eshop", "game-key"                    |
-> | 🟢    | "xbox", "xbo"                     |
+> | 🟢    | "xbox", "xbo", "xbl"                                         |
 > | ♨    | "steam"                                                      |
 > | 👴    | "gog", "good old games"                                      |
 > | 🎮    | "ps4", "ps5", "playstation", "psn", "ps+"            |

--- a/functions/deals.js
+++ b/functions/deals.js
@@ -3,7 +3,7 @@
 const PLATFORM_MAP = [
   { keywords: ['figure', 'plush', 'costume', 'toy', 'ornament', 'amiibo'], emoji: '🕴' }, // Moved up
   { keywords: ['nintendo', 'switch', 'eshop', 'game-key'], emoji: '🔀' }, 
-  { keywords: ['xbox', 'xbo'], emoji: '🟢' },
+  { keywords: ['xbox', 'xbo', 'xbl'], emoji: '🟢' },
   { keywords: ['steam'], emoji: '♨' },
   { keywords: ['gog', 'good old games'], emoji: '👴' },
   { keywords: ['ps4', 'ps5', 'playstation', 'psn', 'ps+'], emoji: '🎮' }, 

--- a/tests/deals.test.js
+++ b/tests/deals.test.js
@@ -288,6 +288,7 @@ describe('onRequest handler for /deals', () => {
       { name: 'Nintendo Switch Game', expectedEmoji: '🔀' },
       { name: 'Xbox Series X bundle', expectedEmoji: '🟢' },
       { name: 'XBO game', expectedEmoji: '🟢' },
+      { name: 'XBL deal', expectedEmoji: '🟢' },
       { name: 'Steam key for PC game', expectedEmoji: '♨' },
       { name: 'GOG classic title', expectedEmoji: '👴' },
       { name: 'PS5 new release', expectedEmoji: '🎮' },


### PR DESCRIPTION
This change updates the platform mapping to include 'xbl' as a keyword for Xbox deals. The requirements and tests have been updated to reflect this change.